### PR TITLE
add a notification about a required "thruster"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ This gem makes it possible to use [Thruster][] as a Capybara server. Run your br
 
 ## Getting started
 
+### Prerequisites
+
+Before adding the gem to your project, ensure you have either `thruster` or `anycable-thruster` installed. You can add one of these gems to your `Gemfile`:
+
+```ruby
+# For thruster
+gem "thruster"
+
+# or for anycable-thruster
+gem "anycable-thruster"
+```
+
 Adding the gem to your project:
 
 ```ruby

--- a/lib/capybara/dependency_checker.rb
+++ b/lib/capybara/dependency_checker.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Capybara
+  module Thruster
+    class DependencyChecker
+      def self.call
+        new.call
+      end
+
+      def call
+        unless thruster_installed?
+          warn "*********************************************************"
+          warn "Warning: capybara-thruster requires either 'thruster' or 'anycable-thruster' gem."
+          warn "Please install one of them to ensure proper functionality."
+          warn "*********************************************************"
+        end
+      end
+
+      private
+
+      def thruster_installed?
+        gem_installed?("thruster") || gem_installed?("anycable-thruster")
+      end
+
+      def gem_installed?(name)
+        Gem::Specification.find_all_by_name(name).any?
+      end
+    end
+  end
+end

--- a/lib/capybara/thruster.rb
+++ b/lib/capybara/thruster.rb
@@ -2,6 +2,10 @@
 
 require "childprocess"
 require "capybara"
+require "capybara/dependency_checker"
+require "rack/handler"
+
+Capybara::Thruster::DependencyChecker.call
 
 # Replaces the default Puma server on CAPYBARA_SERVER_PORT port with Thruster server.
 # Requests are proxied to the Puma server running on the internal port (CAPYBARA_SERVER_PORT + 1).


### PR DESCRIPTION
## What is the purpose of this pull request?
Fixes #1 

## What changes did you make? (overview)
Added a notification about a required "thruster" in every running test if "thruster" or "anycable-thruster" does not exist.

## Checklist
- [x] I've updated a documentation

